### PR TITLE
Fix chunk unloading

### DIFF
--- a/src/main/java/net/smoofyuniverse/mirage/impl/network/NetworkWorld.java
+++ b/src/main/java/net/smoofyuniverse/mirage/impl/network/NetworkWorld.java
@@ -546,7 +546,7 @@ public class NetworkWorld implements WorldView {
 	}
 
 	public boolean isChunkLoaded(int x, int z) {
-		return getChunk(x, z) != null;
+		return this.world.isChunkLoaded(x, z);
 	}
 
 	@Nullable

--- a/src/main/java/net/smoofyuniverse/mirage/mixin/world/WorldMixin.java
+++ b/src/main/java/net/smoofyuniverse/mirage/mixin/world/WorldMixin.java
@@ -25,6 +25,7 @@ package net.smoofyuniverse.mirage.mixin.world;
 import com.flowpowered.math.vector.Vector2i;
 import com.google.common.collect.ImmutableList;
 import net.minecraft.world.World;
+import net.minecraft.world.chunk.Chunk;
 import net.minecraft.world.chunk.IChunkProvider;
 import net.minecraft.world.gen.ChunkProviderServer;
 import net.smoofyuniverse.mirage.api.volume.ChunkStorage;
@@ -34,6 +35,7 @@ import net.smoofyuniverse.mirage.impl.network.NetworkWorld;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.common.bridge.world.chunk.ChunkProviderBridge;
 
 import javax.annotation.Nullable;
 import java.util.Collection;
@@ -79,7 +81,10 @@ public abstract class WorldMixin implements InternalWorld {
 
 	@Override
 	public boolean isChunkLoaded(int x, int z) {
-		return getChunk(x, z) != null;
+		final Chunk chunk = ((ChunkProviderBridge) this.chunkProvider)
+				.bridge$getLoadedChunkWithoutMarkingActive(x, z);
+
+		return chunk != null && !chunk.unloadQueued;
 	}
 
 	@Override


### PR DESCRIPTION
Don't reset Chunk.unloadQueued to false

<details>
  <summary>net.minecraft.world.chunk.ChunkProviderServer.getLoadedChunk(int x, int z)</summary>

```java
    @Nullable
    public Chunk getLoadedChunk(int x, int z)
    {
        long i = ChunkPos.asLong(x, z);
        Chunk chunk = (Chunk)this.loadedChunks.get(i);

        if (chunk != null)
        {
            chunk.unloadQueued = false;
        }

        return chunk;
    }
```
</details>

<details>
  <summary>Visualization of loaded chunks with Dynmap (screenshots)</summary>

![2020-06-21_00-32-40](https://user-images.githubusercontent.com/1076914/85212288-0a551c80-b35a-11ea-9ed9-c1ab4df60b34.png)
![2020-06-21_00-31-58](https://user-images.githubusercontent.com/1076914/85212290-0e813a00-b35a-11ea-8c7c-8383f0a7b0fe.png)
![2020-06-21_00-32-14](https://user-images.githubusercontent.com/1076914/85212291-1345ee00-b35a-11ea-8111-6b5b7a45fd0c.png)
![2020-06-21_00-32-26](https://user-images.githubusercontent.com/1076914/85212292-16d97500-b35a-11ea-8892-69ce0f78593a.png)
</details>

Without Mirage, chunks were correctly unloaded. This PR makes this possible with Mirage installed. Maybe not 100%, but clearly better than it was.