### PR TITLE
Optimize chunk change broadcasting, dynamism scanning, and network allocations

### DIFF
--- a/src/main/java/net/smoofyuniverse/mirage/impl/network/NetworkSection.java
+++ b/src/main/java/net/smoofyuniverse/mirage/impl/network/NetworkSection.java
@@ -185,13 +185,22 @@ public class NetworkSection {
 		if (this.hasNoDynamism())
 			return;
 
-		for (int y = 0; y < 16; y++) {
-			for (int z = 0; z < 16; z++) {
-				for (int x = 0; x < 16; x++) {
-					int d = getDynamism(x, y, z);
-					if (d != 0)
-						section.add(x, y, z, d);
-				}
+		byte[] data = this.dynamism.getData();
+		for (int i = 0; i < data.length; i++) {
+			byte b = data[i];
+			if (b == 0)
+				continue;
+
+			int d0 = b & 15;
+			if (d0 != 0) {
+				int idx = i << 1;
+				section.add(idx & 15, (idx >> 8) & 15, (idx >> 4) & 15, d0);
+			}
+
+			int d1 = (b >> 4) & 15;
+			if (d1 != 0) {
+				int idx = (i << 1) | 1;
+				section.add(idx & 15, (idx >> 8) & 15, (idx >> 4) & 15, d1);
 			}
 		}
 	}

--- a/src/main/java/net/smoofyuniverse/mirage/impl/network/change/BlockChanges.java
+++ b/src/main/java/net/smoofyuniverse/mirage/impl/network/change/BlockChanges.java
@@ -22,6 +22,7 @@
 
 package net.smoofyuniverse.mirage.impl.network.change;
 
+import it.unimi.dsi.fastutil.objects.ObjectIterator;
 import it.unimi.dsi.fastutil.shorts.Short2ObjectMap;
 import it.unimi.dsi.fastutil.shorts.Short2ObjectMap.Entry;
 import it.unimi.dsi.fastutil.shorts.Short2ObjectOpenHashMap;
@@ -90,7 +91,9 @@ public class BlockChanges {
 			p.states = new BlockState[changes];
 
 			int i = 0;
-			for (Entry<BlockState> e : this.blocks.short2ObjectEntrySet()) {
+			ObjectIterator<Entry<BlockState>> it = this.blocks.short2ObjectEntrySet().fastIterator();
+			while (it.hasNext()) {
+				Entry<BlockState> e = it.next();
 				p.positions[i] = e.getShortKey();
 				p.states[i++] = e.getValue();
 			}

--- a/src/main/java/net/smoofyuniverse/mirage/impl/network/dynamic/DynamicSection.java
+++ b/src/main/java/net/smoofyuniverse/mirage/impl/network/dynamic/DynamicSection.java
@@ -151,6 +151,10 @@ public final class DynamicSection {
 		return this.modified;
 	}
 
+	public boolean isCurrentEmpty() {
+		return this.currentPositions.isEmpty();
+	}
+
 	public void applyChanges() {
 		if (this.modified) {
 			this.currentPositions.clear();

--- a/src/main/java/net/smoofyuniverse/mirage/impl/network/dynamic/DynamicWorld.java
+++ b/src/main/java/net/smoofyuniverse/mirage/impl/network/dynamic/DynamicWorld.java
@@ -60,7 +60,7 @@ public final class DynamicWorld {
 		DynamicChunk chunk = this.chunks.get(pos);
 		if (chunk == null) {
 			chunk = new DynamicChunk(this, this.storage.opaqueChunk(x, z));
-			this.chunks.put(asLong(x, z), chunk);
+			this.chunks.put(pos, chunk);
 			chunk.updateCenter();
 		}
 		return chunk;

--- a/src/main/java/net/smoofyuniverse/mirage/mixin/level/ChunkHolderMixin.java
+++ b/src/main/java/net/smoofyuniverse/mirage/mixin/level/ChunkHolderMixin.java
@@ -208,19 +208,23 @@ public abstract class ChunkHolderMixin extends GenerationChunkHolder implements 
 	@Override
 	public void updateDynamism(int x, int y, int z, int distance) {
 		if (this.dynamismEnabled) {
-			getDynamicChunks().forEach(c -> c.update(x, y, z, distance));
+			for (ServerPlayer p : getPlayers(false)) {
+				DynamicChunk c = ((InternalPlayer) p).getDynamicChunk(this.pos.x, this.pos.z);
+				if (c != null)
+					c.update(x, y, z, distance);
+			}
 			markChanged();
 		}
-	}
-
-	private Stream<DynamicChunk> getDynamicChunks() {
-		return getPlayers(false).stream().map(p -> ((InternalPlayer) p).getDynamicChunk(this.pos.x, this.pos.z)).filter(Objects::nonNull);
 	}
 
 	@Override
 	public void clearDynamism() {
 		if (this.dynamismEnabled) {
-			getDynamicChunks().forEach(DynamicChunk::clear);
+			for (ServerPlayer p : getPlayers(false)) {
+				DynamicChunk c = ((InternalPlayer) p).getDynamicChunk(this.pos.x, this.pos.z);
+				if (c != null)
+					c.clear();
+			}
 			markChanged();
 		}
 	}

--- a/src/main/java/net/smoofyuniverse/mirage/mixin/level/ChunkHolderMixin.java
+++ b/src/main/java/net/smoofyuniverse/mirage/mixin/level/ChunkHolderMixin.java
@@ -112,12 +112,16 @@ public abstract class ChunkHolderMixin extends GenerationChunkHolder implements 
 						DynamicChunk dynChunk = ((InternalPlayer) p).getDynamicChunk(this.pos.x, this.pos.z);
 
 						for (int i = 0; i < this.changedBlocksPerSection.length; i++) {
-							int y = this.levelHeightAccessor.getSectionYFromSectionIndex(i);
 							DynamicSection dynSection = dynChunk == null ? null : dynChunk.sections[i];
+							ShortSet storageChanges = this.changedBlocksPerSection[i];
+							boolean hasDynChanges = dynSection != null && dynSection.hasChanges();
+							if (storageChanges == null && !hasDynChanges)
+								continue;
+
+							int y = this.levelHeightAccessor.getSectionYFromSectionIndex(i);
 							BlockChanges changes = new BlockChanges(chunk, y);
 							int minY = y << 4;
 
-							ShortSet storageChanges = this.changedBlocksPerSection[i];
 							if (storageChanges != null) {
 								ShortIterator it = storageChanges.iterator();
 								while (it.hasNext()) {
@@ -127,7 +131,7 @@ public abstract class ChunkHolderMixin extends GenerationChunkHolder implements 
 								}
 							}
 
-							if (dynSection != null) {
+							if (hasDynChanges) {
 								dynSection.getChanges(changes);
 								dynSection.applyChanges();
 							}

--- a/src/main/java/net/smoofyuniverse/mirage/mixin/network/PlayerChunkSenderMixin.java
+++ b/src/main/java/net/smoofyuniverse/mirage/mixin/network/PlayerChunkSenderMixin.java
@@ -61,7 +61,8 @@ public class PlayerChunkSenderMixin {
             for (DynamicSection section : dynChunk.sections) {
                 if (section != null) {
                     section.applyChanges();
-                    section.getCurrent().sendTo(player);
+                    if (!section.isCurrentEmpty())
+                        section.getCurrent().sendTo(player);
                 }
             }
         }


### PR DESCRIPTION
This pull request optimizes hot network and dynamism execution paths to reduce CPU time and eliminate unnecessary heap allocations.

### Performance Improvements:
- **Skip Empty Section Changes Allocation in Chunk Broadcast**: Prevents creating `BlockChanges` and `Short2ObjectOpenHashMap` instances for unchanged chunk sections during block update broadcasting. This change eliminates thousands of short-lived allocations per second on active servers with multiple players.
- **Direct DataLayer Byte Scanning in collectDynamicPositions**: Replaces 4,096 triple-nested loop iterations per section with a linear scan over the 2,048-byte array, immediately skipping zero bytes. This significantly reduces CPU overhead when players move through obfuscated areas.
- **Loop-Based Dynamism Update Iteration**: Replaces stream allocations in `updateDynamism` and `clearDynamism` with direct enhanced for-loops, removing Stream and predicate overhead.
- **Avoid Empty BlockChanges Allocation on Chunk Send**: Guards `DynamicSection.getCurrent().sendTo(...)` with `isCurrentEmpty()` check in `PlayerChunkSenderMixin`, preventing unnecessary object allocations across all 24 sections when sending newly loaded chunks.
- **Zero-Allocation Entry Iteration in BlockChanges**: Utilizes fastutil's `fastIterator()` to reuse the entry object during multi-block update packet construction, eliminating garbage allocations on block change packets.
- **Reuse Hash Key in DynamicWorld**: Reuses the computed long coordinate key in `getOrCreateChunk` instead of recalculating it.